### PR TITLE
Limit npm package contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "1.0.4",
   "description": "Anchorage support plugin for poi",
   "main": "index.es",
+  "files": [
+    "README-CN.MD",
+    "i18n",
+    "index.js",
+    "index.js.map"
+  ],
   "scripts": {
     "prepack": "tsdown",
     "dev": "tsdown --watch",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "poi-plugin-anchorage-repair",
   "version": "1.0.4",
   "description": "Anchorage support plugin for poi",
-  "main": "index.es",
+  "main": "index.js",
   "files": [
     "README-CN.MD",
     "i18n",


### PR DESCRIPTION
## Summary

- Add a `files` whitelist to `package.json`.
- Keep runtime bundle files, locale assets, and `README-CN.MD` in the package.
- Exclude CI, Node/tooling config, workspace metadata, and TypeScript config from the packed tarball.

## Verification

- `npm pack --dry-run`

## Dry-run tarball contents

- `LICENSE`
- `README.MD`
- `README-CN.MD`
- `i18n/*.json`
- `index.js`
- `index.js.map`
- `package.json`